### PR TITLE
Fix link to examples page in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 
 Have a look around the different categories on how to use this framework
 
-*If you don't find a wiki page you need, you should check out the [examples](https://github.com/freya022/BotCommands/tree/3.X/src/examples)*
+*If you don't find a wiki page you need, you should check out the [examples](https://github.com/freya022/BotCommands/tree/3.X/BotCommands-core/src/examples)*

--- a/docs/setup/getting-started-spring-boot.md
+++ b/docs/setup/getting-started-spring-boot.md
@@ -209,7 +209,7 @@ and [Using components](../using-components.md).
 
 ### Examples
 
-You can find examples covering parts of the framework [here](https://github.com/freya022/BotCommands/tree/3.X/src/examples).
+You can find examples covering parts of the framework [here](https://github.com/freya022/BotCommands/tree/3.X/BotCommands-core/src/examples).
 
 ### Getting help
 

--- a/docs/setup/getting-started.md
+++ b/docs/setup/getting-started.md
@@ -330,7 +330,7 @@ and [Using components](../using-components.md).
 
 ### Examples
 
-You can find examples covering parts of the framework [here](https://github.com/freya022/BotCommands/tree/3.X/src/examples).
+You can find examples covering parts of the framework [here](https://github.com/freya022/BotCommands/tree/3.X/BotCommands-core/src/examples).
 
 ### Getting help
 

--- a/docs/using-commands/application-commands/writing-slash-commands.md
+++ b/docs/using-commands/application-commands/writing-slash-commands.md
@@ -435,7 +435,3 @@ All you now need to do is enable `usePredefinedChoices` on your option.
 You can optionally get more info on what changed in your application commands,
 by enabling the `TRACE` logs on `io.github.freya022.botcommands.internal.commands.application.diff.DiffLogger`,
 or any package it is in.
-
-## Examples
-
-You can take a look at more examples [here](https://github.com/freya022/BotCommands/tree/3.X/src/examples#examples).


### PR DESCRIPTION
Reported on Discord.
The examples were moved during the modularization, specifically, in this commit:
https://github.com/freya022/BotCommands/commit/800ca143d8e28b8c035171527491e95b786da434